### PR TITLE
[Jace] Amazon W3 PR

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,62 +5,273 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="./src/style/style.css" />
+    <script type="module" src="./src/js/index.js"></script>
     <title>Amazon.com. Spend less. Smile more.</title>
   </head>
   <body>
-    <div id="nav-wrap">
-      <header class="nav-bar">
-        <nav class="nav-bar__main">
-          <div class="logo">
-            <img src="./src/assets/logo.svg" />
+    <header id="nav-bar">
+      <!---------------nav-bar__main---------------->
+      <nav class="nav-bar__main">
+        <a href="#" class="logo">
+          <img src="./src/assets/logo.svg" />
+        </a>
+        <!-----shipping-address------>
+        <div class="shipping-address">
+          <div class="shipping-address__label">
+            <img src="./src/assets/location.svg" />
+            <p>배송처</p>
           </div>
-          <div class="shipping-address">
-            <div class="shipping-address__label">
-              <img src="./src/assets/location.svg" />
-              <p>배송처</p>
+          <div class="shipping-address__country">
+            <p>대한민국</p>
+          </div>
+          <div class="shipping-address__modal">
+            <div class="shipping-modal-content__msg">
+              <p>KR로 배송할 품목을 표시하겠습니다. 다른 국가로 배송되는 품목을 보려면 배송 주소를 변경하십시오.</p>
             </div>
-            <div class="shipping-address__country">
-              <p>대한민국</p>
+            <div class="shipping-modal-content__btn">
+              <button class="continue__btn">계속</button>
+              <button class="change-address__btn">주소 변경</button>
             </div>
           </div>
-          <div class="search-bar">
-            <input type="text" placeholder="검색 Amazon" />
-            <button>
-              <img src="./src/assets/search.svg" />
-            </button>
+        </div>
+        <!-----search-bar------>
+        <form class="search-bar">
+          <input type="text" placeholder="검색 Amazon" />
+          <button>
+            <img src="./src/assets/search.svg" />
+          </button>
+          <div class="search-bar__expand-auto">
+            <ul>
+              <li>코드스쿼드 아마존 쇼핑몰</li>
+              <li>클론 프로젝트</li>
+              <li>코드스쿼드 아마존 쇼핑몰</li>
+              <li>클론 프로젝트</li>
+              <li>코드스쿼드 아마존 쇼핑몰</li>
+              <li>클론 프로젝트</li>
+              <li>코드스쿼드 아마존 쇼핑몰</li>
+              <li>클론 프로젝트</li>
+              <li>코드스쿼드 아마존 쇼핑몰</li>
+              <li>클론 프로젝트</li>
+            </ul>
           </div>
-          <div class="nation">
-            <img src="./src/assets/flag.svg" />
-            <p>US</p>
+          <div class="search-bar__expand-recommend">
+            <ul>
+              <div class="history-items">
+                <li>내가 검색한 단어</li>
+                <button>
+                  <img src="./src/assets/close.svg" />
+                </button>
+              </div>
+              <div class="history-items">
+                <li>내가 검색한 단어</li>
+                <button>
+                  <img src="./src/assets/close.svg" />
+                </button>
+              </div>
+              <div class="history-items">
+                <li>내가 검색한 단어</li>
+                <button>
+                  <img src="./src/assets/close.svg" />
+                </button>
+              </div>
+              <div class="history-items">
+                <li>내가 검색한 단어</li>
+                <button>
+                  <img src="./src/assets/close.svg" />
+                </button>
+              </div>
+              <div class="history-items">
+                <li>내가 검색한 단어</li>
+                <button>
+                  <img src="./src/assets/close.svg" />
+                </button>
+              </div>
+              <div class="recommend-items">
+                <img src="./src/assets/arrow-top-right.svg" />
+                <li>추천 검색어</li>
+              </div>
+              <div class="recommend-items">
+                <img src="./src/assets/arrow-top-right.svg" />
+                <li>추천 검색어</li>
+              </div>
+              <div class="recommend-items">
+                <img src="./src/assets/arrow-top-right.svg" />
+                <li>추천 검색어</li>
+              </div>
+              <div class="recommend-items">
+                <img src="./src/assets/arrow-top-right.svg" />
+                <li>추천 검색어</li>
+              </div>
+              <div class="recommend-items">
+                <img src="./src/assets/arrow-top-right.svg" />
+                <li>추천 검색어</li>
+              </div>
+              <div class="recommend-items">
+                <img src="./src/assets/arrow-top-right.svg" />
+                <li>추천 검색어</li>
+              </div>
+              <div class="recommend-items">
+                <img src="./src/assets/arrow-top-right.svg" />
+                <li>추천 검색어</li>
+              </div>
+              <div class="recommend-items">
+                <img src="./src/assets/arrow-top-right.svg" />
+                <li>추천 검색어</li>
+              </div>
+              <div class="recommend-items">
+                <img src="./src/assets/arrow-top-right.svg" />
+                <li>추천 검색어</li>
+              </div>
+              <div class="recommend-items">
+                <img src="./src/assets/arrow-top-right.svg" />
+                <li>추천 검색어</li>
+              </div>
+              <div class="recommend-items">
+                <img src="./src/assets/arrow-top-right.svg" />
+                <li>추천 검색어</li>
+              </div>
+            </ul>
           </div>
-          <div class="login">
+        </form>
+        <!-----nation------>
+        <div class="nation">
+          <img src="./src/assets/flag.svg" />
+          <p>US</p>
+        </div>
+        <!-----login------>
+        <div class="login">
+          <div class="login__label">
             <p>안녕하세요, 로그인</p>
             <p>계정 및 목록</p>
           </div>
-          <div class="my-page">
-            <p>반품</p>
-            <p>&주문</p>
+          <div class="login__modal">
+            <div class="login-modal-content__btn">
+              <button>로그인</button>
+            </div>
+            <div class="login-modal-content__msg">
+              <p>기존 사용자가 아니십니까?</p>
+              <a href="#">
+                <p>여기에서 시작합니다</p>
+              </a>
+            </div>
           </div>
-          <div class="cart">
-            <img src="./src/assets/cart.svg" />
-            <p>장바구니</p>
+          <div class="login__modal-expand">
+            <div class="login-modal-expand__btn">
+              <button>로그인</button>
+            </div>
+            <div class="login-modal-expand__msg">
+              <p>기존 사용자가 아니십니까?</p>
+              <a href="#">
+                <p>여기에서 시작합니다</p>
+              </a>
+            </div>
+            <div class="login-modal-expand__divider"></div>
+            <div class="login-modal-expand__menu">
+              <div class="menu__your-list">
+                <p>귀하의 목록</p>
+                <p>목록 생성</p>
+                <p>목록 또는 레지스트리 찾기</p>
+                <p>AmazonSmile 자선 품목 목록</p>
+              </div>
+              <div class="menu__account">
+                <p>계정</p>
+                <p>계정</p>
+                <p>주문</p>
+                <p>권장 사항</p>
+                <p>검색 기록</p>
+                <p>워치리스트</p>
+                <p>비디오 구매 및 대여</p>
+                <p>Kindle 언리미티드</p>
+                <p>콘텐츠 및 기기</p>
+                <p>항목 구독 및 저장</p>
+                <p>멤버십 및 구독</p>
+                <p>음악 라이브러리</p>
+              </div>
+            </div>
           </div>
-        </nav>
-        <nav class="nav-bar__sub">
-          <div class="sliding-drawer">
+        </div>
+        <!-----my-page------>
+        <div class="my-page">
+          <p>반품</p>
+          <p>&주문</p>
+        </div>
+        <!-----cart------>
+        <div class="cart">
+          <img src="./src/assets/cart.svg" />
+          <p>장바구니</p>
+        </div>
+      </nav>
+      <!---------------nav-bar__sub---------------->
+      <nav class="nav-bar__sub">
+        <div class="sub-menu__left">
+          <div class="side-bar__btn">
             <img src="./src/assets/menu.svg" />
             <p>모두</p>
           </div>
-          <ul class="sliding-drawer__menu">
+          <ul class="sub-menu__left-items">
             <li>오늘의 딜</li>
             <li>고객 서비스</li>
             <li>레지스트리</li>
             <li>기프트 카드</li>
             <li>기프트 판매</li>
           </ul>
-        </nav>
-      </header>
-    </div>
-    <div id="content-wrap"></div>
+        </div>
+        <div class="sub-menu__right">
+          <p>지금 특가 상품 쇼핑하기</p>
+        </div>
+      </nav>
+    </header>
+    <main id="content-wrap"></main>
+    <aside id="side-bar">
+      <div class="side-bar__close">
+        <button>
+          <img src="./src/assets/close.svg" />
+        </button>
+      </div>
+      <div class="side-bar__login">
+        <img src="./src/assets/user.svg" />
+        <p>안녕하세요, 로그인</p>
+      </div>
+      <div class="side-bar__category">
+        <p>디지털 콘텐츠 및 기기</p>
+        <ul class="category-digital">
+          <li>Amazon Music</li>
+          <img src="./src/assets/chevron-right.svg" />
+        </ul>
+        <ul class="category-digital">
+          <li>Kindle E-Reader 및 도서</li>
+          <img src="./src/assets/chevron-right.svg" />
+        </ul>
+        <ul class="category-digital">
+          <li>안드로이드 앱스토어</li>
+          <img src="./src/assets/chevron-right.svg" />
+        </ul>
+      </div>
+      <div class="side-bar__divider"></div>
+      <div class="side-bar__category">
+        <p>부서별 쇼핑</p>
+        <ul class="category-section">
+          <li>전자</li>
+          <img src="./src/assets/chevron-right.svg" />
+        </ul>
+        <ul class="category-section">
+          <li>컴퓨터</li>
+          <img src="./src/assets/chevron-right.svg" />
+        </ul>
+        <ul class="category-section">
+          <li>Alexa 스마트 홈</li>
+          <img src="./src/assets/chevron-right.svg" />
+        </ul>
+        <ul class="category-section">
+          <li>예술 및 공예</li>
+          <img src="./src/assets/chevron-right.svg" />
+        </ul>
+        <ul class="category-section__default">
+          <li>모두 보기</li>
+          <img src="./src/assets/chevron-down.svg" />
+        </ul>
+      </div>
+      <div class="side-bar__divider"></div>
+    </aside>
   </body>
 </html>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,0 +1,1 @@
+const shippingAddressModal = document.querySelector(".shipping-address-modal");

--- a/src/style/common.css
+++ b/src/style/common.css
@@ -2,15 +2,16 @@
   box-sizing: border-box;
 }
 
+a {
+  cursor: pointer;
+}
+
 button {
   border: none;
+  cursor: pointer;
 }
 
 input {
   border: none;
   outline: none;
-}
-
-dialog {
-  cursor: default;
 }

--- a/src/style/reset.css
+++ b/src/style/reset.css
@@ -104,7 +104,8 @@ body {
   line-height: 1;
 }
 ol,
-ul {
+ul,
+li {
   list-style: none;
 }
 a {

--- a/src/style/style.css
+++ b/src/style/style.css
@@ -3,33 +3,37 @@
 @import url(./common.css);
 @import url(./theme.css);
 
-#nav-wrap {
+.logo,
+.shipping-address__label,
+.shipping-address__country,
+.nation,
+.login__label p,
+.my-page,
+.cart,
+.sub-menu__left,
+.sub-menu__right,
+.search-bar__expand-auto,
+.recommend-items,
+.category-digita,
+.category-section,
+.category-section__default {
+  cursor: pointer;
+}
+
+#nav-bar {
   width: 100%;
   min-width: 1280px;
   height: 88px;
-  background-color: var(--color-black);
 }
 
+/* nav-bar__main */
 .nav-bar__main {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
   height: 56px;
-  width: 100%;
-}
-
-.logo,
-.shipping-address,
-.search-bar button,
-.nation,
-.login,
-.my-page,
-.cart,
-.sliding-drawer,
-.sliding-drawer__menu,
-.modal-area__btn button {
-  cursor: pointer;
+  background-color: var(--color-black);
 }
 
 .logo {
@@ -37,7 +41,9 @@
   margin: 8px 24px 8px 16px;
 }
 
+/* shipping-address */
 .shipping-address {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -67,49 +73,67 @@
   color: var(--color-white);
 }
 
-.shipping-address-modal {
-  /* display: none; */
+.shipping-address__modal {
+  display: none;
+  position: absolute;
+  top: 44.5px;
+  left: -9px;
   width: 320px;
   height: 126px;
   padding: 16px;
   border: none;
   border-radius: 4px;
   background-color: var(--color-white);
-  z-index: 1;
+  z-index: 2;
 }
 
-.modal-area__msg {
+.shipping-address__modal::before {
+  content: "";
+  position: absolute;
+  top: -10px;
+  left: 10.82px;
+  width: 0;
+  height: 0;
+  border-right: 20.15px solid transparent;
+  border-left: 20.15px solid transparent;
+  border-bottom: calc(20.15px * 1.732) solid var(--color-white);
+  z-index: -2;
+}
+
+.shipping-modal-content__msg {
   margin-bottom: 26px;
 }
 
-.modal-area__msg p {
+.shipping-modal-content__msg p {
   font: var(--font-body-sm), "Pretendard Variable";
 }
 
-.modal-area__btn {
+.shipping-modal-content__btn {
   display: flex;
   justify-content: flex-end;
 }
 
-.modal-area__btn button {
-  border: 1px solid #de9408;
+.shipping-modal-content__btn button {
+  border: 1px solid var(--color-primary-yellow-300);
   border-radius: 4px;
   background: linear-gradient(174.6deg, #ffffff 4.31%, #fed15f 50.01%, #febe30 95.71%);
   font: var(--font-bold-sm), "Pretendard Variable";
 }
 
-.modal-area__btn button:first-child {
+.shipping-modal-content__btn button:first-child {
   width: 39px;
   height: 32px;
   margin-right: 8px;
 }
 
-.modal-area__btn button:last-child {
+.shipping-modal-content__btn button:last-child {
   width: 58px;
   height: 32px;
 }
 
+/* search-bar */
 .search-bar {
+  position: relative;
   display: flex;
   margin: 0 24px;
   flex-grow: 1;
@@ -129,8 +153,10 @@
 }
 
 .search-bar button {
-  background-color: var(--color-primary-orange-100);
+  width: 40px;
+  height: 40px;
   border-radius: 0 4px 4px 0;
+  background-color: var(--color-primary-orange-100);
 }
 
 .search-bar > button > img {
@@ -139,6 +165,112 @@
   filter: invert(6%) sepia(8%) saturate(2088%) hue-rotate(176deg) brightness(94%) contrast(96%);
 }
 
+.search-bar__expand-auto {
+  display: none;
+  position: absolute;
+  width: 100%;
+  min-width: 738px;
+  min-height: 370px;
+  top: 41px;
+  left: -1px;
+  border: 1px solid var(--color-black);
+  border-radius: 4px;
+  background: var(--color-white);
+  z-index: 2;
+}
+.search-bar__expand-auto li {
+  font: var(--font-body-md), "Pretendard Variable";
+  padding: 8px 12px;
+}
+
+.search-bar__expand-auto li:not(:first-child):hover,
+li:not(last-child):hover {
+  background: var(--color-gray-100);
+}
+
+.search-bar__expand-auto li:first-child:hover {
+  background: var(--color-gray-100);
+  border-top-right-radius: 4px;
+  border-top-left-radius: 4px;
+}
+
+.search-bar__expand-auto li:last-child:hover {
+  background: var(--color-gray-100);
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+}
+
+.search-bar__expand-recommend {
+  display: none;
+  position: absolute;
+  width: 100%;
+  min-width: 738px;
+  min-height: 370px;
+  top: 41px;
+  left: -1px;
+  border: 1px solid var(--color-black);
+  border-radius: 4px;
+  background: var(--color-white);
+  z-index: 2;
+}
+
+.history-items {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+}
+
+.history-items button {
+  width: 16px;
+  height: 16px;
+  background: none;
+}
+
+.history-items > button > img {
+  width: 16px;
+  height: 16px;
+}
+
+.history-items li {
+  font: var(--font-body-md), "Pretendard Variable";
+  color: var(--color-secondary-purple);
+}
+
+.recommend-items {
+  display: flex;
+  align-items: center;
+  padding: 8px 15.33px;
+}
+
+.recommend-items img {
+  width: 14px;
+  height: 14px;
+}
+
+.recommend-items li {
+  margin-left: 7.33px;
+  font: var(--font-body-md), "Pretendard Variable";
+}
+
+.recommend-items:not(:first-child):hover,
+.recommend-items:not(:last-child):hover {
+  background: var(--color-gray-100);
+}
+
+.recommend-items:first-child:hover {
+  background: var(--color-gray-100);
+  border-top-right-radius: 4px;
+  border-top-left-radius: 4px;
+}
+
+.recommend-items:last-child:hover {
+  background: var(--color-gray-100);
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+}
+
+/* nation */
 .nation {
   display: flex;
   align-items: center;
@@ -156,20 +288,164 @@
   margin-right: 24px;
 }
 
+/* login */
 .login {
+  position: relative;
   margin-right: 24px;
 }
 
-.login p:first-child {
+.login__label p:first-child {
   font: var(--font-bold-sm), "Pretendard Variable";
   color: var(--color-gray-400);
 }
 
-.login p:last-child {
+.login__label p:last-child {
   font: var(--font-bold-md), "Pretendard Variable";
   color: var(--color-white);
 }
 
+.login__modal {
+  position: absolute;
+  display: none;
+  /* display: flex; */
+  flex-direction: column;
+  align-items: center;
+  width: 242px;
+  height: 90px;
+  padding: 16px;
+  top: 44.5px;
+  right: 0px;
+  border-radius: 4px;
+  background-color: var(--color-white);
+  z-index: 2;
+}
+
+.login__modal::before {
+  content: "";
+  position: absolute;
+  top: -10px;
+  right: 19.62px;
+  width: 0;
+  height: 0;
+  border-right: 20.15px solid transparent;
+  border-left: 20.15px solid transparent;
+  border-bottom: calc(20.15px * 1.732) solid var(--color-white);
+  z-index: -2;
+}
+
+.login-modal-content__btn button {
+  width: 160px;
+  height: 32px;
+  margin-bottom: 8px;
+  border: 1px solid var(--color-primary-yellow-300);
+  border-radius: 4px;
+  background: linear-gradient(174.6deg, #ffffff 4.31%, #fed15f 50.01%, #febe30 95.71%);
+  font: var(--font-bold-sm), "Pretendard Variable";
+}
+
+.login-modal-content__msg {
+  display: flex;
+}
+
+.login-modal-content__msg p:first-child {
+  font: var(--font-body-sm), "Pretendard Variable";
+  margin-right: 3px;
+}
+
+.login-modal-content__msg p:last-child {
+  font: var(--font-body-sm), "Pretendard Variable";
+  color: var(--color-secondary-navy);
+}
+
+.login__modal-expand {
+  position: absolute;
+  display: none;
+  /* display: flex; */
+  flex-direction: column;
+  align-items: center;
+  width: 335px;
+  height: 365px;
+  padding: 16px;
+  top: 44.5px;
+  right: 0px;
+  border-radius: 4px;
+  background-color: var(--color-white);
+  z-index: 2;
+}
+
+.login__modal-expand::before {
+  content: "";
+  position: absolute;
+  top: -10px;
+  right: 19.62px;
+  width: 0;
+  height: 0;
+  border-right: 20.15px solid transparent;
+  border-left: 20.15px solid transparent;
+  border-bottom: calc(20.15px * 1.732) solid var(--color-white);
+  z-index: -2;
+}
+
+.login-modal-expand__btn button {
+  width: 160px;
+  height: 32px;
+  margin-bottom: 8px;
+  border: 1px solid var(--color-primary-yellow-300);
+  border-radius: 4px;
+  background: linear-gradient(174.6deg, #ffffff 4.31%, #fed15f 50.01%, #febe30 95.71%);
+  font: var(--font-bold-sm), "Pretendard Variable";
+}
+
+.login-modal-expand__msg {
+  display: flex;
+}
+
+.login-modal-expand__msg p:first-child {
+  font: var(--font-body-sm), "Pretendard Variable";
+  margin-right: 3px;
+}
+
+.login-modal-expand__msg p:last-child {
+  font: var(--font-body-sm), "Pretendard Variable";
+  color: var(--color-secondary-navy);
+}
+
+.login-modal-expand__divider {
+  width: 100%;
+  height: 1px;
+  margin: 8px 0;
+  background-color: var(--color-gray-100);
+}
+
+.login-modal-expand__menu {
+  display: flex;
+  width: 303px;
+  height: 258px;
+}
+
+.menu__your-list {
+  width: 50%;
+}
+
+.menu__your-list p {
+  font: var(--font-bold-md), "Pretendard Variable";
+  margin-bottom: 4px;
+}
+
+.menu__your-list p:not(:first-child) {
+  font: var(--font-body-sm), "Pretendard Variable";
+}
+
+.menu__account p {
+  font: var(--font-bold-md), "Pretendard Variable";
+  margin-bottom: 4px;
+}
+
+.menu__account p:not(:first-child) {
+  font: var(--font-body-sm), "Pretendard Variable";
+}
+
+/* my-page */
 .my-page {
   margin-right: 24px;
 }
@@ -184,6 +460,7 @@
   color: var(--color-white);
 }
 
+/* cart */
 .cart {
   display: flex;
   align-items: center;
@@ -196,42 +473,187 @@
 .cart p {
   font: var(--font-bold-md), "Pretendard Variable";
   color: var(--color-white);
-  margin-left: 6.3px;
+  margin: 0 16px 0 6.3px;
 }
 
+/* nav-bar__sub */
 .nav-bar__sub {
   display: flex;
   align-items: center;
-  align-content: flex-start;
+  justify-content: space-between;
   min-width: 1280px;
   height: 32px;
   background-color: var(--color-gray-900);
 }
 
-.sliding-drawer {
+#side-bar {
+  position: relative;
+}
+
+.side-bar__close {
+  position: absolute;
+  top: 12px;
+  left: 325px;
+}
+
+.side-bar__close button {
+  background: none;
+}
+
+.side-bar__close img {
+  width: 24px;
+  height: 24px;
+}
+
+.sub-menu__left {
+  position: relative;
   display: flex;
   align-items: center;
 }
 
-.sliding-drawer img {
+.side-bar__btn {
+  display: flex;
+  align-items: center;
+}
+
+.side-bar__btn img {
   width: 16px;
   height: 16px;
   margin: 0 6px 0 26px;
   filter: invert(100%) sepia(0%) saturate(1%) hue-rotate(137deg) brightness(103%) contrast(101%);
 }
 
-.sliding-drawer p {
+.side-bar__btn p {
   margin-right: 16px;
   font: var(--font-bold-md), "Pretendard Variable";
   color: var(--color-white);
 }
 
-.sliding-drawer__menu {
+.sub-menu__left-items {
   display: flex;
 }
 
-.sliding-drawer__menu li {
+.sub-menu__left-items li {
   margin-right: 16px;
   font: var(--font-bold), "Pretendard Variable";
   color: var(--color-white);
+}
+
+.sub-menu__right p {
+  margin-right: 16px;
+  font: var(--font-bold-md), "Pretendard Variable";
+  color: var(--color-white);
+}
+
+#content-wrap {
+  min-width: 1280px;
+}
+
+#content-wrap::after {
+  content: "";
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  background: var(--color-black-40);
+  z-index: 1;
+}
+
+#side-bar {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 320px;
+  height: 100%;
+  background-color: var(--color-white);
+  z-index: 2;
+}
+
+.side-bar__login {
+  display: flex;
+  align-items: center;
+  height: 53px;
+  padding: 16px 16px 16px 33.5px;
+  background-color: var(--color-black);
+}
+
+.side-bar__login img {
+  width: 24px;
+  height: 24px;
+  margin-right: 9.5px;
+  filter: invert(100%) sepia(100%) saturate(0%) hue-rotate(5deg) brightness(104%) contrast(101%);
+}
+
+.side-bar__login p {
+  font: var(--font-bold-lg), "Pretendard Variable";
+  color: var(--color-white);
+}
+
+.side-bar__category {
+  padding: 16px 16px 0 32px;
+}
+
+.side-bar__category p {
+  margin-bottom: 25.5px;
+  font: var(--font-bold-lg), "Pretendard Variable";
+}
+
+.category-digital {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 19px;
+}
+
+.category-digital:last-child {
+  margin-bottom: 9.5px;
+}
+
+.category-digital li {
+  font: var(--font-body-md), "Pretendard Variable";
+}
+
+.category-digital img {
+  width: 24px;
+  height: 24px;
+  filter: invert(61%) sepia(1%) saturate(446%) hue-rotate(316deg) brightness(87%) contrast(86%);
+}
+
+.side-bar__divider {
+  width: 100%;
+  height: 1px;
+  background-color: var(--color-gray-100);
+}
+
+.category-section {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 19px;
+}
+
+.category-section li {
+  font: var(--font-body-md), "Pretendard Variable";
+}
+
+.category-section img {
+  width: 24px;
+  height: 24px;
+  filter: invert(61%) sepia(1%) saturate(446%) hue-rotate(316deg) brightness(87%) contrast(86%);
+}
+
+.category-section__default {
+  display: flex;
+  align-items: center;
+  margin-bottom: 9.5px;
+}
+
+.category-section__default li {
+  font: var(--font-body-md), "Pretendard Variable";
+  margin-right: 14px;
+}
+
+.category-section__default img {
+  width: 24px;
+  height: 24px;
+  filter: invert(61%) sepia(1%) saturate(446%) hue-rotate(316deg) brightness(87%) contrast(86%);
 }

--- a/src/style/theme.css
+++ b/src/style/theme.css
@@ -55,7 +55,7 @@
 :root {
   /* font */
   --font-bold-xl: 900 28px "Pretendard Variable";
-  --font-bold-lg: 900 18px "Pretendard Variable";
+  --font-bold-lg: 800 18px "Pretendard Variable";
   --font-bold-md: 800 13px "Pretendard Variable";
   --font-bold: 600 13px "Pretendard Variable";
   --font-bold-sm: 600 11px "Pretendard Variable";


### PR DESCRIPTION
### 📝 계획

- 네비게이션 바 및 모달, 사이드 바 등의 기본적인 UI(HTML, CSS) 구현 완료
- 이번 주부터 UX 기능(모달, 검색, API)을 구현하기 위한 JS 학습 및 구현에 몰입할 예정

***
### 📌 기능 요구사항

⌗ **Side-bar**
- [ ] 네비게이션 바 서브의 `[모두]` 버튼 클릭 시 좌측에서 사이드바가 애니메이션과 함께 나타나며 배경은 딤처리(`[X]` 버튼 클릭 시 사이드바 close)
- [ ] 사이드바 내 `[모두 보기]` 버튼 클릭 시 애니메이션과 함께 모든 카테고리 메뉴가 unfold되며 `[모두 보기]` 버튼은 `[간략히 보기]`로 변경(반대로, `[간략히 보기]` 버튼 클릭 시 모든 카테고리 메뉴 fold)
- [ ] '부서별 쇼핑' 하위 카테고리 클릭 시 상세 카테고리 레이어가 우측에서 좌측으로 애니메이션과 함께 나타나며 `[주메뉴]` 영역 클릭 시 애니메이션과 함께 좌측에서 우측으로 해당 레이어 제거

⌗ **Search-input**

- [ ] 검색바 클릭 시 추천 검색어 10개가 표시된 레이어가 나타나며 배경은 딤처리(레이어 외 영역 클릭 시 레이어 close)
- [ ] 키보드 `[↓, ↑, ←, →]` 방향키를 통해 추천 검색어 목록 간 이동 기능 및 목록 배경색 포커싱 색상 표시
- [ ] 검색어 입력 시 연관 자동완성 검색어 10개가 표시된 레이어가 나타나며 배경은 딤처리(레이어 외 영역 클릭 시 레이어 close)
- [ ] 키보드 `[↓, ↑, ←, →]` 방향키를 통해 자동완성 검색어 목록 간 이동 기능 및 목록 배경색 포커싱 색상 표시
- [ ] 검색어 검색 후 검색 내역 단어 5개가 추천 검색어 레이어 위에 추가되며, `[X]` 버튼 클릭 시 목록에서 해당 검색어 삭제
- [ ] 키보드 `[↓, ↑, ←, →]` 방향키를 통해 검색 내역 & 추천 검색어 목록 간 이동 기능 및 목록 배경색 포커싱 색상 표시

⌗ **Modal**

- [ ] 페이지 최초 진입 후 1초 뒤 `[로그인]` 버튼 천천히 표시(`[로그인]` 영역 마우스 호버 전까지 유지)
- [ ] `[로그인]` 영역 마우스 호버 시 계정 관련 확장 레이어가 나타나고 배경은 딤처리(마우스 out 시 레이어 & 딤처리 효과 제거)
- [ ] `[배송처]` 영역 마우스 호버 시  주소 관련 확장 레이어가 나타나고 배경은 딤처리(마우스 out 시 레이어 & 딤처리 효과 제거)

### 📌 프로그래밍 요구사항

- [ ] 검색창의 자동완성 검색어, 사이드바 카테고리(상세/간략) 메뉴 데이터를 `json-server`와 연동해서 get
- [ ] `fetch API`를 활용한 데이터 통신 방식으로 개발(`XHR`, `axios` 사용 금지)
- [ ] `promise` 패턴에 대한 이해가 없다면 `then` 메서드 활용
- [ ] 서버 데이터 구성은 mock data로 활용 가능
